### PR TITLE
Create s3 and dynamodb table for terraform backend.

### DIFF
--- a/init/init.tf
+++ b/init/init.tf
@@ -1,0 +1,25 @@
+provider "aws" {
+  region = "ap-northeast-2"
+}
+
+# S3 bucket for backend
+resource "aws_s3_bucket" "tfstate" {
+  bucket = "tf101-ssg-juyoung-apne2-tfstate"
+
+  versioning {
+    enabled = true # Prevent from deleting tfstate file
+  }
+}
+
+# DynamoDB for terraform state lock
+resource "aws_dynamodb_table" "terraform_state_lock" {
+  name = "terraform-ssg-lock"
+  hash_key = "LockID"
+  billing_mode   = "PAY_PER_REQUEST"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+}


### PR DESCRIPTION
테라폼 빽엔드 설정.
```
  + create

Terraform will perform the following actions:

  # aws_dynamodb_table.terraform_state_lock will be created
  + resource "aws_dynamodb_table" "terraform_state_lock" {
      + arn              = (known after apply)
      + billing_mode     = "PAY_PER_REQUEST"
      + hash_key         = "LockID"
      + id               = (known after apply)
      + name             = "terraform-ssg-lock"
      + stream_arn       = (known after apply)
      + stream_label     = (known after apply)
      + stream_view_type = (known after apply)

      + attribute {
          + name = "LockID"
          + type = "S"
        }

      + point_in_time_recovery {
          + enabled = (known after apply)
        }

      + server_side_encryption {
          + enabled     = (known after apply)
          + kms_key_arn = (known after apply)
        }
    }

  # aws_s3_bucket.tfstate will be created
  + resource "aws_s3_bucket" "tfstate" {
      + acceleration_status         = (known after apply)
      + acl                         = "private"
      + arn                         = (known after apply)
      + bucket                      = "tf101-ssg-juyoung-apne2-tfstate"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + versioning {
          + enabled    = true
          + mfa_delete = false
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```